### PR TITLE
Cast to uint64 when relabeling segmentations in sample data

### DIFF
--- a/finn_builtins/_tests/test_example_data.py
+++ b/finn_builtins/_tests/test_example_data.py
@@ -39,5 +39,5 @@ def test_Fluo_N2DL_Hela(ds_function, img_shape, point_shape):
     assert raw_data.shape == img_shape
     assert seg_data.shape == img_shape
     assert raw_data.dtype == np.uint16
-    assert seg_data.dtype == np.uint16
+    assert seg_data.dtype == np.uint64
     assert points.shape == point_shape

--- a/finn_builtins/example_data.py
+++ b/finn_builtins/example_data.py
@@ -280,15 +280,14 @@ def _convert_tiff_stack_to_zarr(
     files = sorted(tiff_path.glob("*.tif"))
     logger.info("%s time points found.", len(files))
     example_image = tifffile.imread(files[0])
+    dtype = np.uint64 if relabel else example_image.dtype
     data_shape = (len(files), *example_image.shape)
     # prepare zarr
-    zarr_array = _create_zarr(
-        zarr_path, zarr_group, shape=data_shape, dtype=example_image.dtype
-    )
+    zarr_array = _create_zarr(zarr_path, zarr_group, shape=data_shape, dtype=dtype)
     # load and save data in zarr
     max_label = 0
     for t, file in enumerate(files):
-        frame = tifffile.imread(file)
+        frame = tifffile.imread(file).astype(dtype)
         if relabel:
             frame[frame != 0] += max_label
             max_label = int(np.max(frame))


### PR DESCRIPTION
# Proposed Change
Fixes a problem when I added sample data with more segmentations that the labels wrapped. (I didn't actually add the sample data in this PR)

# Checklist
Go through these things before merge. Actions should run automatically to test them, but for information on how to run locally, see CONTRIBUTING.md.

- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if applicable).
- [x] I have checked that the tests pass and I maintained or improved test coverage (if applicable).
- [x] I have written docstrings and checked that they render correctly in the documentation build.