### PR TITLE
Bugfix: Cast track id to int when loading from df

### DIFF
--- a/finn/track_import_export/load_tracks.py
+++ b/finn/track_import_export/load_tracks.py
@@ -225,7 +225,7 @@ def tracks_from_df(
         attrs.update(row_dict)
 
         if "track_id" in df.columns:
-            attrs[NodeAttr.TRACK_ID.value] = row["track_id"]
+            attrs[NodeAttr.TRACK_ID.value] = int(row["track_id"])
 
         # add the node to the graph
         graph.add_node(_id, **attrs)


### PR DESCRIPTION
# Proposed Change
Bugfix: Ensure the track ids are ints when loading from dataframe or csv.

# Checklist

- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if applicable).
- [ ] I have checked that the tests pass and I maintained or improved test coverage (if applicable).
- [ ] I have written docstrings and checked that they render correctly in the documentation build.
