### PR TITLE
88 update export button to save to geff

### DIFF
--- a/finn/track_data_views/views_coordinator/tracks_list.py
+++ b/finn/track_data_views/views_coordinator/tracks_list.py
@@ -4,6 +4,7 @@ from warnings import warn
 
 from fonticon_fa6 import FA6S
 from funtracks.data_model import SolutionTracks, Tracks
+from funtracks.import_export.export_to_geff import export_to_geff
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
     QComboBox,
@@ -197,18 +198,25 @@ class TracksList(QGroupBox):
                 tracks.export_tracks(file_path)
 
         elif export_type == "geff":
-            while True:
-                folder = QFileDialog.getExistingDirectory(
-                    self, "Select Empty Output Folder"
-                )
-                if not folder:
-                    return  # User cancelled
-                folder_path = Path(folder)
+            default_file = f"{default_name}_geff.zarr"
+
+            file_dialog = QFileDialog(self, "Save GeFF File")
+            file_dialog.setFileMode(QFileDialog.AnyFile)
+            file_dialog.setAcceptMode(QFileDialog.AcceptSave)
+            file_dialog.setNameFilter("Zarr folder (*.zarr)")
+            file_dialog.setDefaultSuffix("zarr")
+
+            # Set default selected file
+            base_path = Path.home()
+            file_dialog.selectFile(str(base_path / default_file))
+
+            if file_dialog.exec_():
+                file_path = Path(file_dialog.selectedFiles()[0])
                 try:
-                    tracks.export_to_geff(folder_path)
-                    break
+                    export_to_geff(tracks, file_path, overwrite=True)  # QFileDialog
+                    # already asks whether to do overwrite
                 except ValueError as e:
-                    QMessageBox.warning(self, "Invalid Directory", str(e))
+                    QMessageBox.warning(self, "Export Error", str(e))
 
     def save_tracks(self, item: QListWidgetItem):
         """Saves a tracks object from the list. You must pass the list item that

--- a/finn/track_data_views/views_coordinator/tracks_list.py
+++ b/finn/track_data_views/views_coordinator/tracks_list.py
@@ -15,6 +15,7 @@ from qtpy.QtWidgets import (
     QLabel,
     QListWidget,
     QListWidgetItem,
+    QMessageBox,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -196,10 +197,18 @@ class TracksList(QGroupBox):
                 tracks.export_tracks(file_path)
 
         elif export_type == "geff":
-            folder = QFileDialog.getExistingDirectory(self, "Select Output Folder")
-            if folder:
+            while True:
+                folder = QFileDialog.getExistingDirectory(
+                    self, "Select Empty Output Folder"
+                )
+                if not folder:
+                    return  # User cancelled
                 folder_path = Path(folder)
-                tracks.export_to_geff(folder_path)
+                try:
+                    tracks.export_to_geff(folder_path)
+                    break
+                except ValueError as e:
+                    QMessageBox.warning(self, "Invalid Directory", str(e))
 
     def save_tracks(self, item: QListWidgetItem):
         """Saves a tracks object from the list. You must pass the list item that

--- a/finn/track_data_views/views_coordinator/tracks_list.py
+++ b/finn/track_data_views/views_coordinator/tracks_list.py
@@ -200,7 +200,7 @@ class TracksList(QGroupBox):
         elif export_type == "geff":
             default_file = f"{default_name}_geff.zarr"
 
-            file_dialog = QFileDialog(self, "Save GeFF File")
+            file_dialog = QFileDialog(self, "Save as geff file")
             file_dialog.setFileMode(QFileDialog.AnyFile)
             file_dialog.setAcceptMode(QFileDialog.AcceptSave)
             file_dialog.setNameFilter("Zarr folder (*.zarr)")
@@ -214,7 +214,7 @@ class TracksList(QGroupBox):
                 file_path = Path(file_dialog.selectedFiles()[0])
                 try:
                     export_to_geff(tracks, file_path, overwrite=True)  # QFileDialog
-                    # already asks whether to do overwrite
+                    # already asks whether to overwrite in an existing directory
                 except ValueError as e:
                     QMessageBox.warning(self, "Export Error", str(e))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "typing_extensions>=4.2.0",
     "vispy>=0.14.1,<0.15",
     "wrapt>=1.11.1",
-    "funtracks",
+    "funtracks>=1.1.0",
     "pyqtgraph",
     "fonticon-fontawesome6",
     "zarr<3",


### PR DESCRIPTION
# Proposed Change
Allow export to geff in addition to export to CSV. To test this new feature, click on the 'export' button of an item in the TracksList, and select 'geff'. A QFileDialog should open to allow you to choose a file ending with '.zarr'. If a folder with this name exists already, QFileDialog will ask whether to overwrite. When a valid filepath is chosen, a directory will be created here and the data will be saved as geff.

# Further Comments
Requires closing issue [#56](https://github.com/funkelab/funtracks/issues/56) 
