### PR TITLE
91 implement import dialog for geff graph

### DIFF
--- a/finn/track_data_views/views_coordinator/tracks_list.py
+++ b/finn/track_data_views/views_coordinator/tracks_list.py
@@ -130,8 +130,9 @@ class TracksList(QGroupBox):
         dialog = ImportGeffDialog()
         if dialog.exec_() == QDialog.Accepted:
             tracks = dialog.tracks
+            name = dialog.name
             if tracks is not None:
-                self.add_tracks(tracks, "Tracks from Geff", select=True)
+                self.add_tracks(tracks, name, select=True)
 
     def _load_external_tracks(self):
         dialog = ImportTracksDialog()

--- a/finn/track_data_views/views_coordinator/tracks_list.py
+++ b/finn/track_data_views/views_coordinator/tracks_list.py
@@ -28,6 +28,9 @@ from finn._qt.qt_resources import QColoredSVGIcon
 from finn.track_import_export.menus.import_external_tracks_dialog import (
     ImportTracksDialog,
 )
+from finn.track_import_export.menus.import_from_geff.geff_import_dialog import (
+    ImportGeffDialog,
+)
 
 
 class TrackListWidget(QWidget):
@@ -122,6 +125,13 @@ class TracksList(QGroupBox):
         layout.addWidget(self.tracks_list)
         layout.addLayout(load_menu)
         self.setLayout(layout)
+
+    def _load_tracks_from_geff(self):
+        dialog = ImportGeffDialog()
+        if dialog.exec_() == QDialog.Accepted:
+            tracks = dialog.tracks
+            if tracks is not None:
+                self.add_tracks(tracks, "Tracks from Geff", select=True)
 
     def _load_external_tracks(self):
         dialog = ImportTracksDialog()

--- a/finn/track_data_views/views_coordinator/tracks_list.py
+++ b/finn/track_data_views/views_coordinator/tracks_list.py
@@ -113,7 +113,9 @@ class TracksList(QGroupBox):
 
         load_menu = QHBoxLayout()
         self.dropdown_menu = QComboBox()
-        self.dropdown_menu.addItems(["Motile Run", "External tracks from CSV"])
+        self.dropdown_menu.addItems(
+            ["Motile Run", "External tracks from CSV", "External tracks from geff"]
+        )
 
         load_button = QPushButton("Load")
         load_button.clicked.connect(self.load_tracks)
@@ -262,6 +264,8 @@ class TracksList(QGroupBox):
             self.load_motile_run()
         elif self.dropdown_menu.currentText() == "External tracks from CSV":
             self._load_external_tracks()
+        elif self.dropdown_menu.currentText() == "External tracks from geff":
+            self._load_tracks_from_geff()
 
     def load_motile_run(self):
         """Load a set of tracks from disk. The user selects the directory created

--- a/finn/track_import_export/menus/import_from_geff/geff_import_dialog.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_import_dialog.py
@@ -32,6 +32,7 @@ class ImportGeffDialog(QDialog):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Import external tracks from geff")
+        self.name = "Tracks from Geff"
 
         # cancel and finish buttons
         self.button_layout = QHBoxLayout()
@@ -163,6 +164,8 @@ class ImportGeffDialog(QDialog):
             store_path = Path(self.geff_widget.root.store.path)  # e.g. /.../my_store.zarr
             group_path = Path(self.geff_widget.root.path)  # e.g. 'tracks'
             geff_dir = store_path / group_path
+
+            self.name = self.geff_widget.dir_name
             scale = self.scale_widget.get_scale()
 
             segmentation = self.segmentation_widget.get_segmentation()

--- a/finn/track_import_export/menus/import_from_geff/geff_import_dialog.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_import_dialog.py
@@ -193,7 +193,7 @@ class ImportGeffDialog(QDialog):
                 self.tracks = import_from_geff(
                     geff_dir,
                     name_map,
-                    segmentation=segmentation,
+                    segmentation_path=segmentation,
                     extra_features=extra_features,
                     scale=scale,
                 )

--- a/finn/track_import_export/menus/import_from_geff/geff_import_dialog.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_import_dialog.py
@@ -1,0 +1,184 @@
+from pathlib import Path
+
+from funtracks.import_export.import_from_geff import import_from_geff
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QApplication,
+    QDialog,
+    QHBoxLayout,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from finn.track_import_export.menus.import_from_geff.geff_import_widget import (
+    ImportGeffWidget,
+)
+from finn.track_import_export.menus.import_from_geff.geff_prop_map_widget import (
+    StandardFieldMapWidget,
+)
+from finn.track_import_export.menus.import_from_geff.geff_scale_widget import ScaleWidget
+from finn.track_import_export.menus.import_from_geff.geff_segmentation_widgets import (
+    SegmentationWidget,
+)
+
+
+class ImportGeffDialog(QDialog):
+    """Dialgo for importing external tracks from a geff file"""
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Import external tracks from geff")
+
+        # cancel and finish buttons
+        self.button_layout = QHBoxLayout()
+        self.cancel_button = QPushButton("Cancel")
+        self.finish_button = QPushButton("Finish")
+        self.finish_button.setEnabled(False)
+        self.button_layout.addWidget(self.cancel_button)
+        self.button_layout.addWidget(self.finish_button)
+
+        # Connect button signals
+        self.cancel_button.clicked.connect(self._cancel)
+        self.finish_button.clicked.connect(self._finish)
+        self.cancel_button.setDefault(False)
+        self.cancel_button.setAutoDefault(False)
+        self.finish_button.setDefault(False)
+        self.finish_button.setAutoDefault(False)
+
+        # Initialize widgets and connect to update signals
+        self.geff_widget = ImportGeffWidget()
+        self.geff_widget.update_buttons.connect(self._update_segmentation_widget)
+        self.segmentation_widget = SegmentationWidget(root=self.geff_widget.root)
+        self.segmentation_widget.none_radio.toggled.connect(
+            self._toggle_scale_widget_and_seg_id
+        )
+        self.prop_map_widget = StandardFieldMapWidget()
+        self.geff_widget.update_buttons.connect(self._update_field_map_widget)
+        self.scale_widget = ScaleWidget()
+
+        self.content_widget = QWidget()
+        main_layout = QVBoxLayout(self.content_widget)
+        main_layout.addWidget(self.geff_widget)
+        main_layout.addWidget(self.segmentation_widget)
+        main_layout.addWidget(self.prop_map_widget)
+        main_layout.addWidget(self.scale_widget)
+        main_layout.addLayout(self.button_layout)
+        self.content_widget.setLayout(main_layout)
+        self.content_widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
+
+        # Create scroll area
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidget(self.content_widget)
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.scroll_area.setMinimumWidth(500)
+        self.scroll_area.setSizePolicy(
+            QSizePolicy.Preferred, QSizePolicy.MinimumExpanding
+        )
+        self.content_widget.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
+
+        dialog_layout = QVBoxLayout()
+        dialog_layout.addWidget(self.scroll_area)
+        self.setLayout(dialog_layout)
+        self.setSizePolicy(self.sizePolicy().horizontalPolicy(), QSizePolicy.Minimum)
+
+    def _resize_dialog(self):
+        """Dynamic widget resizing depending on the visible contents"""
+
+        self.content_widget.adjustSize()
+        self.content_widget.updateGeometry()
+
+        content_hint = self.content_widget.sizeHint()
+        screen_geometry = QApplication.primaryScreen().availableGeometry()
+
+        max_height = int(screen_geometry.height() * 0.85)
+        new_height = min(content_hint.height(), max_height)
+        new_width = max(content_hint.width(), 500)
+
+        self.resize(new_width, new_height)
+
+        # Center horizontally, but upwards if too tall
+        screen_center = screen_geometry.center()
+        x = screen_center.x() - self.width() // 2
+
+        if new_height < screen_geometry.height():
+            y = screen_center.y() - new_height // 2
+        else:
+            y = screen_geometry.top() + 50
+
+        self.move(x, y)
+
+    def _update_segmentation_widget(self) -> None:
+        """Refresh the segmentation widget based on the geff root group."""
+
+        if self.geff_widget.root is not None:
+            self.segmentation_widget.update_root(self.geff_widget.root)
+        else:
+            self.segmentation_widget.setVisible(False)
+        self.finish_button.setEnabled(self.geff_widget.root is not None)
+        self._resize_dialog()
+
+    def _update_field_map_widget(self) -> None:
+        """Prefill the field map widget with the geff metadata and graph attributes."""
+
+        if self.geff_widget.root is not None:
+            self.prop_map_widget.update_mapping(
+                self.geff_widget.root, self.segmentation_widget.include_seg()
+            )
+            self.finish_button.setEnabled(self.geff_widget.root is not None)
+            self.scale_widget._prefill_from_metadata(
+                dict(self.geff_widget.root.attrs.get("geff", {}))
+            )
+        else:
+            self.prop_map_widget.setVisible(False)
+            self.scale_widget.setVisible(False)
+        self.finish_button.setEnabled(self.geff_widget.root is not None)
+        self._resize_dialog()
+
+    def _toggle_scale_widget_and_seg_id(self, checked: bool) -> None:
+        """Toggle visibility of the scale widget based on the 'None' radio button state,
+        and update the visibility of the 'seg_id' combobox in the prop map widget."""
+
+        self.scale_widget.setVisible(not checked)
+
+        # Also remove the seg_id from the fields widget
+        if len(self.prop_map_widget.mapping_widgets) > 0:
+            self.prop_map_widget.mapping_widgets["seg_id"].setVisible(not checked)
+            self.prop_map_widget.mapping_labels["seg_id"].setVisible(not checked)
+        self._resize_dialog()
+
+    def _cancel(self) -> None:
+        """Close the dialog without loading tracks."""
+        self.reject()
+
+    def _finish(self) -> None:
+        """Tries to read the geff file and optional segmentation image and apply the
+        attribute to column mapping to construct a Tracks object"""
+
+        if self.geff_widget.root is not None:
+            store_path = Path(self.geff_widget.root.store.path)  # e.g. /.../my_store.zarr
+            group_path = Path(self.geff_widget.root.path)  # e.g. 'tracks'
+            geff_dir = store_path / group_path
+            scale = self.scale_widget.get_scale()
+
+            segmentation = self.segmentation_widget.get_segmentation()
+            name_map = self.prop_map_widget.get_name_map()
+            name_map = {k: (None if v == "None" else v) for k, v in name_map.items()}
+            extra_features = self.prop_map_widget.get_optional_props()
+
+            try:
+                self.tracks = import_from_geff(
+                    geff_dir,
+                    name_map,
+                    segmentation=segmentation,
+                    extra_features=extra_features,
+                    scale=scale,
+                )
+            except (ValueError, OSError, FileNotFoundError, AssertionError) as e:
+                QMessageBox.critical(self, "Error", f"Failed to load tracks: {e}")
+                return
+            self.accept()

--- a/finn/track_import_export/menus/import_from_geff/geff_import_dialog.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_import_dialog.py
@@ -164,6 +164,9 @@ class ImportGeffDialog(QDialog):
         if len(self.prop_map_widget.mapping_widgets) > 0:
             self.prop_map_widget.mapping_widgets["seg_id"].setVisible(not checked)
             self.prop_map_widget.mapping_labels["seg_id"].setVisible(not checked)
+            self.prop_map_widget.optional_features["area"]["recompute"].setEnabled(
+                not checked
+            )
 
         self._update_finish_button()
         self._resize_dialog()

--- a/finn/track_import_export/menus/import_from_geff/geff_import_utils.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_import_utils.py
@@ -1,0 +1,40 @@
+import zarr
+from qtpy.QtWidgets import (
+    QLayout,
+)
+
+
+def find_geff_group(group: zarr.Group) -> zarr.Group | None:
+    """Recursively search for a Zarr group with 'geff' in its .zattrs.
+    Args:
+        group (zarr.Group): The Zarr group to search within.
+    Returns:
+        zarr.Group | None: The first group found with 'geff' in its .zattrs, or None if
+        not found.
+    """
+
+    if "geff" in group.attrs:
+        return group
+
+    for key in group.group_keys():
+        subgroup = group[key]
+        if isinstance(subgroup, zarr.Group):
+            found = find_geff_group(subgroup)
+            if found:
+                return found
+    return None
+
+
+def clear_layout(layout: QLayout) -> None:
+    """Recursively clear all widgets and layouts in a QLayout.
+    Args:
+        layout (QLayout): The layout to clear.
+    """
+    while layout.count():
+        item = layout.takeAt(0)
+        widget = item.widget()
+        if widget is not None:
+            widget.setParent(None)
+        # If the item is a layout itself, clear it recursively
+        elif item.layout() is not None:
+            clear_layout(item.layout())

--- a/finn/track_import_export/menus/import_from_geff/geff_import_widget.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_import_widget.py
@@ -1,0 +1,100 @@
+import os
+from pathlib import Path
+
+import zarr
+from psygnal import Signal
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+from zarr.storage import FSStore
+
+from finn.track_import_export.menus.import_from_geff.geff_import_utils import (
+    find_geff_group,
+)
+
+
+class ImportGeffWidget(QWidget):
+    """QWidget for selecting geff directory"""
+
+    update_buttons = Signal()
+
+    def __init__(self):
+        super().__init__()
+
+        self.root = None
+
+        # QlineEdit for geff file path and browse button
+        self.geff_path_line = QLineEdit(self)
+        self.geff_path_line.setFocus()
+        self.geff_path_line.setFocusPolicy(Qt.StrongFocus)
+        self.geff_path_line.returnPressed.connect(self._on_line_editing_finished)
+        self.geff_browse_button = QPushButton("Browse", self)
+        self.geff_browse_button.setAutoDefault(0)
+        self.geff_browse_button.clicked.connect(self._browse_geff)
+
+        browse_layout = QHBoxLayout()
+        browse_layout.addWidget(self.geff_path_line)
+        browse_layout.addWidget(self.geff_browse_button)
+
+        box = QGroupBox("Path to geff zarr directory")
+        box_layout = QVBoxLayout()
+        box_layout.addLayout(browse_layout)
+        box.setLayout(box_layout)
+        main_layout = QVBoxLayout()
+        main_layout.addWidget(box)
+        self.setLayout(main_layout)
+
+    def _on_line_editing_finished(self) -> None:
+        """Load the geff group when the user presses Enter in the path line"""
+
+        folder_path = self.geff_path_line.text().strip()
+        if not folder_path:
+            self.root = None
+            self.update_buttons.emit()  # to remove any widgets and disable finish button
+        else:
+            # try to load, will raise an error if no zarr group can be found
+            self._load_geff(Path(folder_path))
+
+    def _browse_geff(self) -> None:
+        """Open File dialog to select geff folder"""
+
+        folder = QFileDialog.getExistingDirectory(self, "Select Geff Zarr directory")
+        if folder:
+            folder_path = Path(folder)
+            self.geff_path_line.setText(str(folder_path))
+            self._load_geff(folder_path)
+
+    def _load_geff(self, folder_path: Path) -> None:
+        """Load the graph and display the geffFieldMapWidget"""
+
+        self.root = None
+        if not os.path.exists(folder_path):
+            QMessageBox.critical(self, "Error", f"Path does not exist: {folder_path}")
+            self.update_buttons.emit()
+            return
+        try:
+            store = FSStore(folder_path)
+            root = zarr.group(store=store)
+        except (KeyError, ValueError, OSError) as e:
+            QMessageBox.critical(self, "Error", f"Could not open zarr store: {e}")
+            self.update_buttons.emit()
+            return
+
+        geff_group = find_geff_group(root)
+        if geff_group is None:
+            QMessageBox.critical(
+                self, "Error", "No geff group found in the selected directory."
+            )
+            self.update_buttons.emit()
+            return
+
+        self.root = geff_group
+        self.update_buttons.emit()

--- a/finn/track_import_export/menus/import_from_geff/geff_import_widget.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_import_widget.py
@@ -30,6 +30,7 @@ class ImportGeffWidget(QWidget):
         super().__init__()
 
         self.root = None
+        self.dir_name = None
 
         # QlineEdit for geff file path and browse button
         self.geff_path_line = QLineEdit(self)
@@ -97,4 +98,5 @@ class ImportGeffWidget(QWidget):
             return
 
         self.root = geff_group
+        self.dir_name = os.path.basename(folder_path)
         self.update_buttons.emit()

--- a/finn/track_import_export/menus/import_from_geff/geff_prop_map_widget.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_prop_map_widget.py
@@ -1,0 +1,230 @@
+import difflib
+
+import zarr
+from funtracks.data_model.graph_attributes import NodeAttr
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+from finn.track_import_export.menus.import_from_geff.geff_import_utils import (
+    clear_layout,
+)
+
+
+class StandardFieldMapWidget(QWidget):
+    """QWidget to map motile attributes to geff node properties."""
+
+    def __init__(
+        self,
+    ):
+        super().__init__()
+
+        self.node_attrs = []
+        self.metadata = None
+        self.mapping_labels = {}
+        self.mapping_widgets = {}
+
+        # Group box for property field mapping
+        box = QGroupBox("Property mapping")
+        box_layout = QHBoxLayout()
+        box.setLayout(box_layout)
+        main_layout = QVBoxLayout()
+
+        main_layout.addWidget(box)
+        self.setLayout(main_layout)
+
+        # Graph data mapping Layout
+        mapping_box = QGroupBox("Graph data")
+        mapping_box.setToolTip(
+            "<html><body><p style='white-space:pre-wrap; width: 300px;'>"
+            "Map spatiotemporal attributes and optional track and lineage attributes to "
+            "geff node properties."
+        )
+        self.mapping_layout = QFormLayout()
+        mapping_box.setLayout(self.mapping_layout)
+        box_layout.addWidget(mapping_box, alignment=Qt.AlignTop)
+
+        # Optional features
+        optional_box = QGroupBox("Optional features")
+        optional_box.setToolTip(
+            "<html><body><p style='white-space:pre-wrap; width: 300px;'>"
+            "Optionally select additional features to be imported. If the 'Recompute' "
+            "checkbox is checked, the feature will be recomputed, otherwise it will "
+            "directly be imported from the data."
+        )
+        self.optional_mapping_layout = QVBoxLayout()
+        optional_box.setLayout(self.optional_mapping_layout)
+        box_layout.addWidget(optional_box, alignment=Qt.AlignTop)
+
+        self.setVisible(False)
+
+    def update_mapping(self, root: zarr.Group | None = None, seg: bool = False) -> None:
+        """Update the mapping widget with the provided root group and segmentation
+        flag."""
+
+        if root is not None:
+            self.setVisible(True)
+            self.node_attrs = list(root["nodes"]["props"].group_keys())
+            self.metadata = dict(root.attrs.get("geff", {}))
+
+            self.props_left = []
+            self.standard_fields = [
+                NodeAttr.TIME.value,
+                "y",
+                "x",
+                NodeAttr.TRACK_ID.value,
+                "lineage_id",
+            ]
+
+            if seg:
+                self.standard_fields.append("seg_id")
+
+            axes = self.metadata.get("axes", None)
+            if axes is not None:
+                axes_types = [ax.get("type") for ax in axes if ax.get("type") == "space"]
+                if len(axes_types) == 3:
+                    self.standard_fields.insert(1, "z")
+            else:
+                self.standard_fields.insert(
+                    1, "z"
+                )  # also provide the option to choose z if
+                # no axes information is available
+
+            # Map graph spatiotemporal data and optionally the track and lineage
+            # attributes
+            self.mapping_labels = {}
+            self.mapping_widgets = {}
+            clear_layout(self.mapping_layout)  # clear layout first
+            initial_mapping = self._get_initial_mapping()
+            for attribute, geff_attr in initial_mapping.items():
+                if attribute in self.standard_fields:
+                    combo = QComboBox()
+                    combo.addItems(self.node_attrs + ["None"])  # also add None
+                    combo.setCurrentText(geff_attr)
+                    combo.currentIndexChanged.connect(self._update_props_left)
+                    label = QLabel(attribute)
+                    label.setToolTip(self._get_tooltip(attribute))
+                    self.mapping_widgets[attribute] = combo
+                    self.mapping_labels[attribute] = label
+                    self.mapping_layout.addRow(label, combo)
+
+            # Optional extra features
+            clear_layout(self.optional_mapping_layout)
+            self.optional_features = {}
+            for attribute in self.props_left:
+                row_layout = QHBoxLayout()
+                attr_checkbox = QCheckBox(attribute)
+                recompute_checkbox = QCheckBox("Recompute")
+                recompute_checkbox.setEnabled(
+                    False
+                ) if attribute != NodeAttr.AREA.value else recompute_checkbox.setEnabled(
+                    True
+                )
+                row_layout.addWidget(attr_checkbox)
+                row_layout.addWidget(recompute_checkbox)
+                self.optional_mapping_layout.addLayout(row_layout)
+                self.optional_features[attribute] = {
+                    "attr_checkbox": attr_checkbox,
+                    "recompute": recompute_checkbox,
+                }
+        else:
+            self.setVisible(False)
+
+    def _get_tooltip(self, attribute: str) -> str:
+        """Return the tooltip for the given attribute"""
+
+        tooltips = {
+            NodeAttr.TIME.value: "The time point of the node. Must be an integer",
+            "z": "The world z-coordinate of the node.",
+            "y": "The world y-coordinate of the node.",
+            "x": "The world x-coordinate of the node.",
+            NodeAttr.SEG_ID.value: "The integer label value in the segmentation file.",
+            NodeAttr.TRACK_ID.value: "<html><body><p style='white-space:pre-wrap; width: "
+            "300px;'>"
+            "(Optional) The tracklet id that this node belongs "
+            "to, defined as a single chain with at most one incoming and one outgoing "
+            "edge.",
+            "lineage_id": "<html><body><p style='white-space:pre-wrap; width: "
+            "(Optional) Lineage id that this node belongs to, defined as "
+            "weakly connected component in the graph.",
+        }
+
+        return tooltips.get(attribute, "")
+
+    def _update_props_left(self) -> None:
+        """Update the list of columns that have not been mapped yet"""
+
+        self.props_left = [
+            attr for attr in self.node_attrs if attr not in self.get_name_map().values()
+        ]
+
+    def _get_initial_mapping(
+        self,
+    ) -> dict[str:str]:
+        """Make an initial guess for mapping of geff columns to fields"""
+
+        mapping = {}
+        self.props_left: list = self.node_attrs.copy()
+
+        # check if the axes information is in the metadata, if so, use it for initial
+        # mapping
+        if hasattr(self.metadata, "axes"):
+            axes_names = [ax.name for ax in self.metadata.axes]
+            for attribute in self.standard_fields:
+                if attribute in axes_names:
+                    mapping[attribute] = attribute
+                    self.props_left.remove(attribute)
+
+        # if fields could not be assigned via the metadata, try find exact matches for
+        # standard fields
+        for attribute in self.standard_fields:
+            if attribute in mapping:
+                continue
+            if attribute in self.props_left:
+                mapping[attribute] = attribute
+                self.props_left.remove(attribute)
+
+        # assign closest remaining column as best guess for remaining standard fields
+        for attribute in self.standard_fields:
+            if attribute in mapping:
+                continue
+            if len(self.props_left) > 0:
+                closest = difflib.get_close_matches(
+                    attribute, self.props_left, n=1, cutoff=0.6
+                )
+                if closest:
+                    mapping[attribute] = closest[0]
+                    self.props_left.remove(closest[0])
+                else:
+                    mapping[attribute] = "None"
+            else:
+                mapping[attribute] = "None"
+
+        return mapping
+
+    def get_name_map(self) -> dict[str:str]:
+        """Return a mapping from feature name to geff field name"""
+
+        return {
+            attribute: combo.currentText()
+            for attribute, combo in self.mapping_widgets.items()
+        }
+
+    def get_optional_props(self) -> dict[str:bool]:
+        """Get all the extra features that are requested and whether they should be
+        recomputed"""
+
+        optional_features = {}
+        for attr, checkbox_dict in self.optional_features.items():
+            if checkbox_dict["attr_checkbox"].isChecked():
+                optional_features[attr] = checkbox_dict["recompute"].isChecked()
+
+        return optional_features

--- a/finn/track_import_export/menus/import_from_geff/geff_prop_map_widget.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_prop_map_widget.py
@@ -124,11 +124,8 @@ class StandardFieldMapWidget(QWidget):
                 row_layout = QHBoxLayout()
                 attr_checkbox = QCheckBox(attribute)
                 recompute_checkbox = QCheckBox("Recompute")
-                recompute_checkbox.setEnabled(
-                    False
-                ) if attribute != NodeAttr.AREA.value else recompute_checkbox.setEnabled(
-                    True
-                )
+                activate_checkbox = bool(attribute == NodeAttr.AREA.value and seg)
+                recompute_checkbox.setEnabled(activate_checkbox)
                 row_layout.addWidget(attr_checkbox)
                 row_layout.addWidget(recompute_checkbox)
                 self.optional_mapping_layout.addLayout(row_layout)

--- a/finn/track_import_export/menus/import_from_geff/geff_prop_map_widget.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_prop_map_widget.py
@@ -80,12 +80,10 @@ class StandardFieldMapWidget(QWidget):
                 NodeAttr.TIME.value,
                 "y",
                 "x",
+                "seg_id",
                 NodeAttr.TRACK_ID.value,
                 "lineage_id",
             ]
-
-            if seg:
-                self.standard_fields.append("seg_id")
 
             axes = self.metadata.get("axes", None)
             if axes is not None:
@@ -115,6 +113,9 @@ class StandardFieldMapWidget(QWidget):
                     self.mapping_widgets[attribute] = combo
                     self.mapping_labels[attribute] = label
                     self.mapping_layout.addRow(label, combo)
+                    if attribute == "seg_id" and not seg:
+                        combo.setVisible(False)
+                        label.setVisible(False)
 
             # Optional extra features
             clear_layout(self.optional_mapping_layout)

--- a/finn/track_import_export/menus/import_from_geff/geff_scale_widget.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_scale_widget.py
@@ -1,0 +1,105 @@
+import numpy as np
+from geff.affine import Affine
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+from finn.track_import_export.menus.import_from_geff.geff_import_utils import clear_layout
+
+
+class ScaleWidget(QWidget):
+    """Widget to specify the spatial scaling of the graph in relation to its segmentation
+    data."""
+
+    def __init__(self):
+        super().__init__()
+
+        self.scale = None
+
+        # wrap content layout in a QGroupBox
+        self.scale_layout = QVBoxLayout()
+        box = QGroupBox("Scaling")
+        box.setLayout(self.scale_layout)
+
+        main_layout = QVBoxLayout()
+        main_layout.addWidget(box)
+        main_layout.setAlignment(Qt.AlignTop)
+
+        self.setLayout(main_layout)
+        self.setToolTip(
+            "<html><body><p style='white-space:pre-wrap; width: 300px;'>"
+            "Specify the spatial scaling (pixel to world coordinate) in relation to "
+            "the segmentation data, if provided."
+        )
+        self.setVisible(False)
+
+    def _prefill_from_metadata(self, metadata: dict) -> None:
+        """Update the scale widget, prefilling with metadata information if possible.
+        Args:
+            metadata (dict): geff metadata dictionary containing 'affine' and 'axes' keys.
+        """
+
+        if len(metadata) > 0:
+            self.setVisible(True)
+            clear_layout(self.scale_layout)
+            self.scale_form_layout = QFormLayout()
+
+            affine = metadata.get("affine")
+            if affine is not None:
+                affine = affine.get("matrix", None)
+                affine = Affine(matrix=affine)
+                linear = affine.linear_matrix
+                self.scale = tuple(np.diag(linear))
+            else:
+                self.scale = [1] * len(metadata.get("axes"))
+
+            # Spinboxes for scaling in (z), y, x.
+            self.z_label = QLabel("z")
+            self.z_spin_box = self._scale_spin_box(self.scale[-3])
+            self.z_label.setVisible(len(self.scale) == 4)
+            self.z_spin_box.setVisible(len(self.scale) == 4)
+            self.y_spin_box = self._scale_spin_box(self.scale[-2])
+            self.x_spin_box = self._scale_spin_box(self.scale[-1])
+
+            self.scale_form_layout.addRow(self.z_label, self.z_spin_box)
+            self.scale_form_layout.addRow(QLabel("y"), self.y_spin_box)
+            self.scale_form_layout.addRow(QLabel("x"), self.x_spin_box)
+
+            self.scale_layout.addLayout(self.scale_form_layout)
+
+    def _scale_spin_box(self, value: float) -> QDoubleSpinBox:
+        """Return a QDoubleSpinBox for scaling values"""
+
+        spin_box = QDoubleSpinBox()
+        spin_box.setValue(value)
+        spin_box.setSingleStep(0.1)
+        spin_box.setMinimum(0)
+        spin_box.setDecimals(3)
+        return spin_box
+
+    def get_scale(self) -> list[float]:
+        """Return the scaling values in the spinboxes as a list of floats. Also return 1
+        for the time dimension.
+        """
+
+        if len(self.scale) == 4:
+            scale = [
+                1,
+                self.z_spin_box.value(),
+                self.y_spin_box.value(),
+                self.x_spin_box.value(),
+            ]
+        else:
+            scale = [
+                1,
+                self.y_spin_box.value(),
+                self.x_spin_box.value(),
+            ]
+
+        return scale

--- a/finn/track_import_export/menus/import_from_geff/geff_segmentation_widgets.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_segmentation_widgets.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import zarr
+from psygnal import Signal
 from qtpy.QtWidgets import (
     QButtonGroup,
     QDialog,
@@ -24,6 +25,8 @@ from finn.track_import_export.menus.import_from_geff.geff_import_utils import (
 
 class ExternalSegmentationWidget(QWidget):
     """Widget for specifying the path to an external segmentation image file or folder."""
+
+    seg_path_updated = Signal()
 
     def __init__(self):
         super().__init__()
@@ -67,6 +70,8 @@ class ExternalSegmentationWidget(QWidget):
             selected_path = dialog.get_selected_path()
             if selected_path:
                 self.image_path_line.setText(selected_path)
+
+        self.seg_path_updated.emit()
 
     def get_segmentation_path(self) -> Path | None:
         """Return the path to the segmentation data."""

--- a/finn/track_import_export/menus/import_from_geff/geff_segmentation_widgets.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_segmentation_widgets.py
@@ -137,7 +137,7 @@ class FileFolderDialog(QDialog):
 
         path = self.path_line_edit.text()
         if path != "" and os.path.exists(path):
-            return Path
+            return path
         return None
 
 

--- a/finn/track_import_export/menus/import_from_geff/geff_segmentation_widgets.py
+++ b/finn/track_import_export/menus/import_from_geff/geff_segmentation_widgets.py
@@ -1,0 +1,250 @@
+import os
+from pathlib import Path
+
+import zarr
+from qtpy.QtWidgets import (
+    QButtonGroup,
+    QDialog,
+    QFileDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QRadioButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from finn.track_import_export.menus.import_from_geff.geff_import_utils import (
+    clear_layout,
+)
+
+
+class ExternalSegmentationWidget(QWidget):
+    """Widget for specifying the path to an external segmentation image file or folder."""
+
+    def __init__(self):
+        super().__init__()
+
+        self.image_path_line = QLineEdit(self)
+        self.image_browse_button = QPushButton("Browse", self)
+        self.image_browse_button.setAutoDefault(0)
+        self.image_browse_button.clicked.connect(self._browse_segmentation)
+
+        image_widget = QWidget()
+        image_layout = QVBoxLayout()
+        image_sublayout = QHBoxLayout()
+        image_sublayout.addWidget(QLabel("Segmentation data path:"))
+        image_sublayout.addWidget(self.image_path_line)
+        image_sublayout.addWidget(self.image_browse_button)
+
+        label = QLabel(
+            "Image data can either be a single tif (3D+time or 2D+time) stack, a "
+            "folder containing a time series of 2D or 3D tif images, or a zarr "
+            "folder."
+        )
+        font = label.font()
+        font.setItalic(True)
+        label.setFont(font)
+        label.setWordWrap(True)
+
+        image_layout.addWidget(label)
+        image_layout.addLayout(image_sublayout)
+        image_widget.setLayout(image_layout)
+        image_widget.setMaximumHeight(100)
+
+        main_layout = QVBoxLayout()
+        main_layout.addWidget(image_widget)
+        self.setLayout(main_layout)
+
+    def _browse_segmentation(self) -> None:
+        """Open custom dialog to select either a file or a folder"""
+
+        dialog = FileFolderDialog(self)
+        if dialog.exec_():
+            selected_path = dialog.get_selected_path()
+            if selected_path:
+                self.image_path_line.setText(selected_path)
+
+    def get_segmentation_path(self) -> Path | None:
+        """Return the path to the segmentation data."""
+
+        path = self.image_path_line.text()
+        if os.path.exists(self.image_path_line.text()):
+            return Path(path)
+        return None
+
+
+class FileFolderDialog(QDialog):
+    """Dialog to select a file or folder for segmentation data."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.setWindowTitle("Choose an image file or a folder containing a time series")
+        self.path_line_edit = QLineEdit(self)
+
+        self.file_button = QPushButton("Select file", self)
+        self.file_button.clicked.connect(self.select_file)
+        self.file_button.setAutoDefault(False)
+        self.file_button.setDefault(False)
+
+        self.folder_button = QPushButton("Select folder", self)
+        self.folder_button.clicked.connect(self.select_folder)
+        self.folder_button.setAutoDefault(False)
+        self.folder_button.setDefault(False)
+
+        self.ok_button = QPushButton("OK", self)
+        self.ok_button.clicked.connect(self.accept)
+
+        button_layout = QHBoxLayout()
+        button_layout.addWidget(self.file_button)
+        button_layout.addWidget(self.folder_button)
+
+        main_layout = QVBoxLayout(self)
+        main_layout.addWidget(self.path_line_edit)
+        main_layout.addLayout(button_layout)
+        main_layout.addWidget(self.ok_button)
+
+    def select_file(self):
+        """Open File dialog to select a file and set it to the line edit."""
+
+        file, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select Segmentation File",
+            "",
+            "Segmentation Files (*.tiff *.zarr *.tif)",
+        )
+        if file:
+            self.path_line_edit.setText(file)
+
+    def select_folder(self):
+        """Open Folder dialog to select a folder and set it to the line edit."""
+
+        folder = QFileDialog.getExistingDirectory(
+            self,
+            "Select Folder",
+            "",
+            QFileDialog.ShowDirsOnly | QFileDialog.DontResolveSymlinks,
+        )
+        if folder:
+            self.path_line_edit.setText(folder)
+
+    def get_selected_path(self) -> Path | None:
+        """Return the path entered in the line edit."""
+
+        path = self.path_line_edit.text()
+        if path != "" and os.path.exists(path):
+            return Path
+        return None
+
+
+class SegmentationWidget(QWidget):
+    """QWidget for specifying pixel calibration"""
+
+    def __init__(self, root: zarr.Group | None = None):
+        super().__init__()
+
+        self.root = root
+
+        # Button group for mutual exclusivity
+        self.button_group = QButtonGroup(self)
+        self.button_group.setExclusive(True)
+        self.related_object_radio_buttons = {}
+
+        # Add "None" option
+        none_radio_layout = QHBoxLayout()
+        self.none_radio = QRadioButton("None")
+        none_radio_layout.addWidget(self.none_radio)
+        self.button_group.addButton(self.none_radio)
+        self.none_radio.setChecked(True)
+
+        # Empty layout to which related objects can be added
+        self.related_objects_layout = QVBoxLayout()
+
+        # External segmentation as a radio button
+        external_segmentation_radio_layout = QVBoxLayout()
+        self.external_segmentation_radio = QRadioButton("Use external segmentation")
+        external_segmentation_radio_layout.addWidget(self.external_segmentation_radio)
+        self.button_group.addButton(self.external_segmentation_radio)
+        self.external_segmentation_radio.toggled.connect(self._toggle_segmentation)
+        self.segmentation_widget = ExternalSegmentationWidget()
+        self.segmentation_widget.setVisible(False)
+
+        # Assemble group box layout
+        box_layout = QVBoxLayout()
+        box_layout.addLayout(none_radio_layout)
+        box_layout.addLayout(self.related_objects_layout)
+        box_layout.addLayout(external_segmentation_radio_layout)
+        box_layout.addWidget(self.segmentation_widget)
+
+        main_layout = QVBoxLayout()
+        box = QGroupBox("Segmentation data")
+        box.setLayout(box_layout)
+        main_layout.addWidget(box)
+        self.setSizePolicy(self.sizePolicy().horizontalPolicy(), QSizePolicy.Minimum)
+        self.setLayout(main_layout)
+
+        self.setToolTip(
+            "<html><body><p style='white-space:pre-wrap; width: 300px;'>"
+            "Optionally select a segmentation image, or use associated data if provided"
+            " in the geff directory."
+        )
+        self.setVisible(False)
+
+    def update_root(self, root: zarr.Group | None) -> None:
+        """Update the root group and populate related objects if available.
+        Args:
+            root (zarr.Group | None): The root group of the geff zarr store.
+        """
+        self.root = root
+        clear_layout(self.related_objects_layout)
+        self.related_object_radio_buttons = {}
+        if self.root is not None:
+            self.setVisible(True)
+            metadata = dict(self.root.attrs)
+            related_objects = metadata.get("geff", {}).get("related_objects", None)
+            if related_objects:
+                for obj in related_objects:
+                    if obj.get("type") == "labels":
+                        radio = QRadioButton(f"Related data: {obj.get('path', None)}")
+                        radio.setChecked(True)
+                        self.button_group.addButton(radio)
+                        self.related_object_radio_buttons[obj.get("path", None)] = radio
+                        self.related_objects_layout.addWidget(radio)
+        else:
+            self.setVisible(False)
+
+    def _toggle_segmentation(self, checked: bool) -> None:
+        """Toggle visibility of the segmentation widget based on the radio button
+        state."""
+        self.segmentation_widget.setVisible(checked)
+        self.adjustSize()
+
+    def include_seg(self) -> bool:
+        """Return True if any segmentation radio button is checked, else False."""
+
+        # Check external segmentation radio
+        if self.external_segmentation_radio.isChecked():
+            return True
+        # Check related object radios
+        for radio in self.related_object_radio_buttons.values():
+            if radio.isChecked():
+                return True
+        return False
+
+    def get_segmentation(self) -> Path | None:
+        """Return the path to selected related object or external segmentation"""
+
+        for path, radio in self.related_object_radio_buttons.items():
+            if radio.isChecked():
+                store_path = Path(self.root.store.path)  # e.g. /.../geff.zarr
+                group_path = Path(self.root.path)  # e.g. 'tracks'
+                full_group_path = store_path / group_path  # /.../geff.zarr/tracks
+                seg_path = (full_group_path / path).resolve()
+                return seg_path
+        if self.external_segmentation_radio.isChecked():
+            return self.segmentation_widget.get_segmentation_path()
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "typing_extensions>=4.2.0",
     "vispy>=0.14.1,<0.15",
     "wrapt>=1.11.1",
-    "funtracks>=1.2.0",
+    "funtracks>=1.2.1",
     "pyqtgraph",
     "fonticon-fontawesome6",
     "zarr<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "typing_extensions>=4.2.0",
     "vispy>=0.14.1,<0.15",
     "wrapt>=1.11.1",
-    "funtracks>=1.1.0",
+    "funtracks>=1.2.0",
     "pyqtgraph",
     "fonticon-fontawesome6",
     "zarr<3",

--- a/scripts/.zgroup
+++ b/scripts/.zgroup
@@ -1,0 +1,3 @@
+{
+    "zarr_format": 2
+}


### PR DESCRIPTION
# Proposed Change
Add a dialog to import SolutionTracks from geff. 

<img width="422" height="540" alt="image" src="https://github.com/user-attachments/assets/bf8b0082-4180-4b17-afbd-6e02b5d0dc47" />

Steps to test:
At the bottom of the TracksList widget, there should be an 'External tracks from geff' option, which opens the dialog above. For segmentation, there are the following options: 'None', 'from related objects' (if any), or 'external'. If a segmentation is chosen, a seg_id key has to be provided, as well the spatial scaling relationship to the data (prefilled if available from the geff metadata affine matrix). 
The dialog checks if a geff dir is provided, and a segmentation file (if requested), but all other validity checking happens on funtracks.import_export.import_from_geff.py

# Further Comments
Needs resolving of 57-import-from-geff-in-addition-to-csv before it can be used. 
