### PR TITLE
Fix starting new track_id by pressing 'M'

### DIFF
--- a/finn/track_data_views/views/layers/track_labels.py
+++ b/finn/track_data_views/views/layers/track_labels.py
@@ -39,19 +39,6 @@ def _new_label(layer: TrackLabels, new_track_id=True):
 
     if isinstance(layer.data, np.ndarray):
         new_selected_label = np.max(layer.data) + 1
-        if layer.selected_label > new_selected_label:
-            show_info(
-                "Current selected label is not being used. You will need to use it first "
-                "to be able to set the current select label to the next one available",
-            )
-            return
-        if layer.selected_label == new_selected_label:
-            new_selected_label += 1  # just add one more, because the ensure_valid_label
-            # function also adds +1 to ensure continuous painting with the same track_id
-            # (but different node_id). If the user pressed 'M' again, we should assume it
-            # means they want to paint a new track_id instead of continuing the current
-            # one.
-            layer.selected_label = new_selected_label
         if new_track_id or layer.selected_track is None:
             new_selected_track = layer.tracks_viewer.tracks.get_next_track_id()
             layer.selected_track = new_selected_track

--- a/finn/track_data_views/views/layers/track_labels.py
+++ b/finn/track_data_views/views/layers/track_labels.py
@@ -39,6 +39,12 @@ def _new_label(layer: TrackLabels, new_track_id=True):
 
     if isinstance(layer.data, np.ndarray):
         new_selected_label = np.max(layer.data) + 1
+        if layer.selected_label > new_selected_label:
+            show_info(
+                "Current selected label is not being used. You will need to use it first "
+                "to be able to set the current select label to the next one available",
+            )
+            return
         if layer.selected_label == new_selected_label:
             new_selected_label += 1  # just add one more, because the ensure_valid_label
             # function also adds +1 to ensure continuous painting with the same track_id


### PR DESCRIPTION
Fix for issue #84 (hopefully)
Allow the user to start a new track by pressing M on the TracksLabels layer, which should assign a color for the next available node id and add it to the colormap. 

Steps to test:
1) Press 'M' on a TracksLabels layer (any tool can be active). Verify that the 'label' value increments and a color is assigned. 
2) Verify that painting with the newly assigned label adds a new node. 
3) Verify that moving forward or backwards in time and painting again auto-increments the label with 1 and connects the nodes. 
4) Verify that pressing 'M' again assigns a new label, and allows you to start a new track_id. 

Notes:
You can assign a new node id by pressing M even if the max value +1 in the array is equal to the currently selected label. The ensure_valid_label function automatically adds +1 to the selected_label when moving in time to ensure that you can continue a track_id without having to select it each time you go to a different time point. If the currently assigned label is larger than the max value +1 in the array, we should not allow the user to add a new label, as they should use the current one first. 